### PR TITLE
[FE] Login Component 구현, 공통 컴포넌트 구현, 폴더구조 변경

### DIFF
--- a/FE/.eslintrc
+++ b/FE/.eslintrc
@@ -47,7 +47,8 @@
     "no-alert": 0,
     "react-hooks/exhaustive-deps": 0,
     "react/jsx-fragments": 0,
-    "import/no-cycle": "off"
+    "import/no-cycle": "off",
+    "no-underscore-dangle": "off"
   },
   "settings": { 
     "import/parsers": {

--- a/FE/.eslintrc
+++ b/FE/.eslintrc
@@ -46,7 +46,8 @@
     "no-empty-pattern": 0,
     "no-alert": 0,
     "react-hooks/exhaustive-deps": 0,
-    "react/jsx-fragments": 0
+    "react/jsx-fragments": 0,
+    "import/no-cycle": "off"
   },
   "settings": { 
     "import/parsers": {

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -1963,6 +1963,18 @@
         "@types/react": "*"
       }
     },
+    "@types/react-redux": {
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.15.tgz",
+      "integrity": "sha512-+piY42tUflPfI7y9Vy3UkG6MEMuJlrxfdtgeUcWmd5Z0qB57NXAPG6smkqu1DNXluo/KDyXPeRYhcFzMwt1BEA==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -2823,6 +2835,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
       "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -5918,11 +5938,18 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "flux-standard-action": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-2.1.1.tgz",
+      "integrity": "sha512-W86GzmXmIiTVq/dpYVd2HtTIUX9c35Iq3ao3xR6qcKtuXgbu+BDEj72op5VnEIe/kpuSbhl+I8kT1iS2hpcusw==",
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "follow-redirects": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-      "dev": true
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -6304,7 +6331,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -7104,6 +7130,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
       "version": "1.1.1",
@@ -9951,6 +9982,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-redux": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
+      "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      }
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -10197,6 +10240,34 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-promise": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/redux-promise/-/redux-promise-0.6.0.tgz",
+      "integrity": "sha512-R2mGxJbPFgXyCNbFDE6LjTZhCEuACF54g1bxld3nqBhnRMX0OsUyWk77moF7UMGkUdl5WOAwc4BC5jOd1dunqQ==",
+      "requires": {
+        "flux-standard-action": "^2.0.3",
+        "is-promise": "^2.1.0"
+      }
+    },
+    "redux-promise-middleware": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.2.tgz",
+      "integrity": "sha512-ZqZu/nnSzGgwTtNbGoGVontpk7LjTOv0kigtt3CcgXI9gpq+8WlfXTXRZD0WTD5yaohRq0q2nYmJXSTjwXs83Q=="
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -11878,6 +11949,11 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
       "version": "5.4.6",

--- a/FE/package.json
+++ b/FE/package.json
@@ -24,6 +24,7 @@
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.2",
     "@types/jest": "^26.0.20",
+    "@types/react-redux": "^7.1.15",
     "@types/styled-components": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
@@ -60,9 +61,15 @@
   "dependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "axios": "^0.21.1",
     "next": "^10.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-redux": "^7.2.2",
+    "redux": "^4.0.5",
+    "redux-promise": "^0.6.0",
+    "redux-promise-middleware": "^6.1.2",
+    "redux-thunk": "^2.3.0",
     "webpack": "^4.44.0"
   }
 }

--- a/FE/src/api/config.ts
+++ b/FE/src/api/config.ts
@@ -1,0 +1,30 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import { urlObjectKeys } from 'next/dist/next-server/lib/utils';
+
+const DOMAIN = '';
+const Config = axios.create();
+
+Config.interceptors.request.use((value: AxiosRequestConfig) => {
+  const config = value;
+  config.params = {
+    ...config.params,
+  };
+  return config;
+});
+
+Config.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    return Promise.reject(error);
+  },
+);
+
+export const Axios = (method: any, url: string, data: any) => {
+  return Config({
+    method,
+    url: DOMAIN + urlObjectKeys,
+    data,
+  })
+    .then((res) => res.data)
+    .catch((err) => console.log(err));
+};

--- a/FE/src/api/index.ts
+++ b/FE/src/api/index.ts
@@ -1,0 +1,5 @@
+import { Axios } from './config';
+
+export const loginAPI = (params: any): Promise<string> => {
+  return Axios('post', '/api/user', params);
+};

--- a/FE/src/components/LoginComponent/LeftComponent/LeftComponent.tsx
+++ b/FE/src/components/LoginComponent/LeftComponent/LeftComponent.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { LeftComponentBackGround, TextDiv } from '../../common';
+
+export const LeftComponent = (): JSX.Element => {
+  console.log('render left');
+  return (
+    <LeftComponentBackGround>
+      <TextDiv size='70px' margin='0px' text='Welcome !' />
+      <TextDiv size='130px' margin='20px' text='Every Portfolio' />
+      <TextDiv size='60px' margin='370px' text='Don’t have your PortFolio?' />
+      <TextDiv size='30px' margin='0px' text='You can make your own portfolio easily' />
+    </LeftComponentBackGround>
+  );
+};

--- a/FE/src/components/LoginComponent/LoginComponent.tsx
+++ b/FE/src/components/LoginComponent/LoginComponent.tsx
@@ -1,87 +1,15 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
-import Link from 'next/link';
-import {
-  TextDiv,
-  TextInput,
-  Button,
-  AuthBackground,
-  LeftComponentBackGround,
-  RightComponentBackGround,
-} from '../common';
+import React from 'react';
+import { AuthBackground } from '../common';
+import { LeftComponent } from './LeftComponent/LeftComponent';
+import { RightComponent } from './RightComponent/RightComponent';
 
-const LinkWrapper = styled.div`
-  margin-top: 100px;
-  font-size: 24px;
-`;
-
-const FlexWrapper = styled.div`
-  display: flex;
-
-  div {
-    margin-left: 10px;
-    margin-top: 0px !important;
-  }
-`;
-
-const LinkDiv = styled.div`
-  margin-top: 20px;
-  color: #2a8de8;
-  cursor: pointer;
-`;
-
-const LoginComponent = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value);
-  };
-
-  const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-  };
-
-  const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault();
-    setEmail('');
-    setPassword('');
-  };
-
+const LoginComponent = (): JSX.Element => {
+  console.log('Component render');
   return (
     <>
       <AuthBackground>
-        <LeftComponentBackGround>
-          <TextDiv size='70px' margin='0px' text='Welcome !' />
-          <TextDiv size='130px' margin='20px' text='Every Portfolio' />
-          <TextDiv size='60px' margin='370px' text='Don’t have your PortFolio?' />
-          <TextDiv size='30px' margin='0px' text='You can make your own portfolio easily' />
-        </LeftComponentBackGround>
-        <RightComponentBackGround>
-          <TextDiv size='80px' margin='0px' text='LOGIN' />
-          <TextInput placeholder='Email' inputType='text' value={email} onChange={onChangeEmail} />
-          <TextInput
-            placeholder='Password'
-            inputType='password'
-            value={password}
-            onChange={onChangePassword}
-          />
-          <Button eventHandler={onClick} text='LOGIN' />
-          <LinkWrapper>
-            <FlexWrapper>
-              <span>New to Every Portfolio? </span>
-              <Link href='/signup'>
-                <LinkDiv>Create an Account!</LinkDiv>
-              </Link>
-            </FlexWrapper>
-            <Link href='/find-id'>
-              <LinkDiv>Forgot your ID ?</LinkDiv>
-            </Link>
-            <Link href='/find-id'>
-              <LinkDiv>Forgot your Password ?</LinkDiv>
-            </Link>
-          </LinkWrapper>
-        </RightComponentBackGround>
+        <LeftComponent />
+        <RightComponent />
       </AuthBackground>
     </>
   );

--- a/FE/src/components/LoginComponent/LoginComponent.tsx
+++ b/FE/src/components/LoginComponent/LoginComponent.tsx
@@ -1,72 +1,33 @@
-import React, { ChangeEvent, ReactEventHandler, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import { TextDiv } from '../common/TextDiv';
-import { TextInput } from '../common/TextInput';
-import { Button } from '../common/Button';
+import Link from 'next/link';
+import {
+  TextDiv,
+  TextInput,
+  Button,
+  AuthBackground,
+  LeftComponentBackGround,
+  RightComponentBackGround,
+} from '../common';
 
-const Wrapper = styled.div`
-  width: 100%;
-  min-height: 100vh;
-  color: white;
-  z-index: 1;
-  position: relative;
-
-  &::after {
-    width: 100%;
-    min-height: 100vh;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-image: url('/static/background.jpg');
-    color: white;
-    z-index: -2;
-    position: absolute;
-    left: 0;
-    top: 0;
-    content: '';
-    opacity: 0.9;
-  }
+const LinkWrapper = styled.div`
+  margin-top: 100px;
+  font-size: 24px;
 `;
 
-const LeftComponent = styled.div`
-  width: 60%;
-  background-color: none;
-  font-size: 60px;
-  padding: 10% 7%;
-  padding-bottom: 0px;
-  color: white;
-`;
-
-const RightComponent = styled.div`
-  width: 40%;
-  font-size: 80px;
-  padding: 10% 5%;
-  padding-bottom: 0px;
-  position: relative;
-
-  &::after {
-    width: 100%;
-    height: 100%;
-    z-index: -1;
-    background-color: black;
-    opacity: 0.7;
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-  }
-
-  input {
-    margin-top: 80px;
-  }
-
-  button {
-    margin-left: 20%;
-  }
-`;
-
-const ComponentWrapper = styled.div`
+const FlexWrapper = styled.div`
   display: flex;
-  height: 100vh;
+
+  div {
+    margin-left: 10px;
+    margin-top: 0px !important;
+  }
+`;
+
+const LinkDiv = styled.div`
+  margin-top: 20px;
+  color: #2a8de8;
+  cursor: pointer;
 `;
 
 const LoginComponent = () => {
@@ -89,27 +50,39 @@ const LoginComponent = () => {
 
   return (
     <>
-      <Wrapper>
-        <ComponentWrapper>
-          <LeftComponent>
-            <TextDiv size='70px' margin='0px' text='Welcome !' />
-            <TextDiv size='130px' margin='20px' text='Every Portfolio' />
-            <TextDiv size='60px' margin='370px' text='Don’t have your PortFolio?' />
-            <TextDiv size='30px' margin='0px' text='You can make your own portfolio easily' />
-          </LeftComponent>
-          <RightComponent>
-            <TextDiv size='80px' margin='0px' text='LOGIN' />
-            <TextInput placeholder='Email' inputType='text' value={email} onChange={onChangeEmail} />
-            <TextInput
-              placeholder='Password'
-              inputType='password'
-              value={password}
-              onChange={onChangePassword}
-            />
-            <Button eventHandler={onClick} text='LOGIN' />
-          </RightComponent>
-        </ComponentWrapper>
-      </Wrapper>
+      <AuthBackground>
+        <LeftComponentBackGround>
+          <TextDiv size='70px' margin='0px' text='Welcome !' />
+          <TextDiv size='130px' margin='20px' text='Every Portfolio' />
+          <TextDiv size='60px' margin='370px' text='Don’t have your PortFolio?' />
+          <TextDiv size='30px' margin='0px' text='You can make your own portfolio easily' />
+        </LeftComponentBackGround>
+        <RightComponentBackGround>
+          <TextDiv size='80px' margin='0px' text='LOGIN' />
+          <TextInput placeholder='Email' inputType='text' value={email} onChange={onChangeEmail} />
+          <TextInput
+            placeholder='Password'
+            inputType='password'
+            value={password}
+            onChange={onChangePassword}
+          />
+          <Button eventHandler={onClick} text='LOGIN' />
+          <LinkWrapper>
+            <FlexWrapper>
+              <span>New to Every Portfolio? </span>
+              <Link href='/signup'>
+                <LinkDiv>Create an Account!</LinkDiv>
+              </Link>
+            </FlexWrapper>
+            <Link href='/find-id'>
+              <LinkDiv>Forgot your ID ?</LinkDiv>
+            </Link>
+            <Link href='/find-id'>
+              <LinkDiv>Forgot your Password ?</LinkDiv>
+            </Link>
+          </LinkWrapper>
+        </RightComponentBackGround>
+      </AuthBackground>
     </>
   );
 };

--- a/FE/src/components/LoginComponent/LoginComponent.tsx
+++ b/FE/src/components/LoginComponent/LoginComponent.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, ReactEventHandler, useState } from 'react';
 import styled from 'styled-components';
 import { TextDiv } from '../common/TextDiv';
 import { TextInput } from '../common/TextInput';
-// import { Button } from '../common/Button';
+import { Button } from '../common/Button';
 
 const Wrapper = styled.div`
   width: 100%;
@@ -18,7 +18,7 @@ const Wrapper = styled.div`
     background-size: cover;
     background-image: url('/static/background.jpg');
     color: white;
-    z-index: -1;
+    z-index: -2;
     position: absolute;
     left: 0;
     top: 0;
@@ -41,10 +41,27 @@ const RightComponent = styled.div`
   font-size: 80px;
   padding: 10% 5%;
   padding-bottom: 0px;
-  z-index: 3;
   position: relative;
-  background-color: black;
-  opacity: 0.7;
+
+  &::after {
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background-color: black;
+    opacity: 0.7;
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+
+  input {
+    margin-top: 80px;
+  }
+
+  button {
+    margin-left: 20%;
+  }
 `;
 
 const ComponentWrapper = styled.div`
@@ -82,16 +99,14 @@ const LoginComponent = () => {
           </LeftComponent>
           <RightComponent>
             <TextDiv size='80px' margin='0px' text='LOGIN' />
-            <TextInput placeholder='email' inputType='text' value={email} onChange={onChangeEmail} />
+            <TextInput placeholder='Email' inputType='text' value={email} onChange={onChangeEmail} />
             <TextInput
-              placeholder='password'
+              placeholder='Password'
               inputType='password'
               value={password}
               onChange={onChangePassword}
             />
-            <button type='button' onClick={(e) => onClick(e)}>
-              제출
-            </button>
+            <Button eventHandler={onClick} text='LOGIN' />
           </RightComponent>
         </ComponentWrapper>
       </Wrapper>

--- a/FE/src/components/LoginComponent/RightComponent/Links/Links.tsx
+++ b/FE/src/components/LoginComponent/RightComponent/Links/Links.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Link from 'next/link';
+import styled from 'styled-components';
+
+const LinkWrapper = styled.div`
+  margin-top: 100px;
+  font-size: 24px;
+`;
+
+const FlexWrapper = styled.div`
+  display: flex;
+
+  div {
+    margin-left: 10px;
+    margin-top: 0px !important;
+  }
+`;
+
+const LinkDiv = styled.div`
+  margin-top: 20px;
+  color: #2a8de8;
+  cursor: pointer;
+`;
+
+export const Links = (): JSX.Element => {
+  return (
+    <LinkWrapper>
+      <FlexWrapper>
+        <span>New to Every Portfolio? </span>
+        <Link href='/signup'>
+          <LinkDiv>Create an Account!</LinkDiv>
+        </Link>
+      </FlexWrapper>
+      <Link href='/find-id'>
+        <LinkDiv>Forgot your ID ?</LinkDiv>
+      </Link>
+      <Link href='/find-pw'>
+        <LinkDiv>Forgot your Password ?</LinkDiv>
+      </Link>
+    </LinkWrapper>
+  );
+};

--- a/FE/src/components/LoginComponent/RightComponent/RightComponent.tsx
+++ b/FE/src/components/LoginComponent/RightComponent/RightComponent.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import { useDispatch } from 'react-redux';
 import { RightComponentBackGround, TextDiv, TextInput, Button } from '../../common';
 import { Links } from './Links/Links';
+import { requestLogin } from '../../../store/modules/user';
 
 export const RightComponent = (): JSX.Element => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const router = useRouter();
+  const dispatch = useDispatch();
 
   console.log('render Right');
 
@@ -23,9 +26,13 @@ export const RightComponent = (): JSX.Element => {
   const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
     console.log('click button');
-    setEmail('');
-    setPassword('');
-    router.push('/');
+    const params = { email, password };
+    dispatch(requestLogin(params)).then((res) => {
+      console.log(res);
+      setEmail('');
+      setPassword('');
+      // router.push('/');
+    });
   };
 
   return (

--- a/FE/src/components/LoginComponent/RightComponent/RightComponent.tsx
+++ b/FE/src/components/LoginComponent/RightComponent/RightComponent.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { RightComponentBackGround, TextDiv, TextInput, Button } from '../../common';
+import { Links } from './Links/Links';
+
+export const RightComponent = (): JSX.Element => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  console.log('render Right');
+
+  const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log('change Email');
+    setEmail(e.target.value);
+  };
+
+  const onChangePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log('change password');
+    setPassword(e.target.value);
+  };
+
+  const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.preventDefault();
+    console.log('click button');
+    setEmail('');
+    setPassword('');
+    router.push('/');
+  };
+
+  return (
+    <RightComponentBackGround>
+      <TextDiv size='80px' margin='0px' text='LOGIN' />
+      <TextInput placeholder='Email' inputType='text' value={email} onChange={onChangeEmail} />
+      <TextInput placeholder='Password' inputType='password' value={password} onChange={onChangePassword} />
+      <Button eventHandler={onClick} text='LOGIN' />
+      <Links />
+    </RightComponentBackGround>
+  );
+};

--- a/FE/src/components/common/AuthBackground.tsx
+++ b/FE/src/components/common/AuthBackground.tsx
@@ -29,7 +29,7 @@ const ComponentWrapper = styled.div`
   height: 100vh;
 `;
 
-export const AuthBackground = ({ children }: { children: JSX.Element }): JSX.Element => {
+export const AuthBackground = ({ children }: { children: JSX.Element[] }): JSX.Element => {
   return (
     <Wrapper>
       <ComponentWrapper>{children}</ComponentWrapper>

--- a/FE/src/components/common/AuthBackground.tsx
+++ b/FE/src/components/common/AuthBackground.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  color: white;
+  z-index: 1;
+  position: relative;
+
+  &::after {
+    width: 100%;
+    min-height: 100vh;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-image: url('/static/background.jpg');
+    color: white;
+    z-index: -2;
+    position: absolute;
+    left: 0;
+    top: 0;
+    content: '';
+    opacity: 0.9;
+  }
+`;
+
+const ComponentWrapper = styled.div`
+  display: flex;
+  height: 100vh;
+`;
+
+export const AuthBackground = ({ children }: { children: JSX.Element }): JSX.Element => {
+  return (
+    <Wrapper>
+      <ComponentWrapper>{children}</ComponentWrapper>
+    </Wrapper>
+  );
+};

--- a/FE/src/components/common/Button.tsx
+++ b/FE/src/components/common/Button.tsx
@@ -6,6 +6,9 @@ const ButtonStyle = styled.button`
   border: 1px solid white;
   color: white;
   text-align: center;
+  width: 30%;
+  height: 5%;
+  font-size: 25px;
 `;
 
 interface ButtonProps {

--- a/FE/src/components/common/LeftComponentBackGround.tsx
+++ b/FE/src/components/common/LeftComponentBackGround.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const LeftComponent = styled.div`
+  width: 60%;
+  background-color: none;
+  font-size: 60px;
+  padding: 10% 7%;
+  padding-bottom: 0px;
+  color: white;
+`;
+
+export const LeftComponentBackGround = ({ children }: { children: JSX.Element[] }): JSX.Element => {
+  return <LeftComponent>{children}</LeftComponent>;
+};

--- a/FE/src/components/common/RightComponentBackground.tsx
+++ b/FE/src/components/common/RightComponentBackground.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const RightComponent = styled.div`
+  width: 40%;
+  padding: 10% 5%;
+  padding-bottom: 0px;
+  position: relative;
+
+  &::after {
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background-color: black;
+    opacity: 0.7;
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+
+  input {
+    margin-top: 80px;
+  }
+
+  button {
+    margin-top: 7%;
+    margin-left: 20%;
+  }
+`;
+
+export const RightComponentBackGround = ({ children }: { children: JSX.Element[] }): JSX.Element => {
+  return <RightComponent>{children}</RightComponent>;
+};

--- a/FE/src/components/common/TextInput.tsx
+++ b/FE/src/components/common/TextInput.tsx
@@ -5,7 +5,7 @@ const Input = styled.input`
   display: block;
   color: white;
   padding-left: 5px;
-  font-size: 17px;
+  font-size: 25px;
   width: 70%;
   height: 45px;
   border-top: 0px;
@@ -21,6 +21,9 @@ const Input = styled.input`
   :-ms-input-placeholder {
     color: white;
     font-size: 20px;
+  }
+  &::placeholder {
+    font-size: 25px;
   }
 `;
 

--- a/FE/src/components/common/TextInput.tsx
+++ b/FE/src/components/common/TextInput.tsx
@@ -36,6 +36,12 @@ interface TextInputProps {
 
 export const TextInput = ({ placeholder, inputType, value, onChange }: TextInputProps): JSX.Element => {
   return (
-    <Input placeholder={placeholder} autoComplete='off' type={inputType} value={value} onChange={onChange} />
+    <Input
+      placeholder={placeholder}
+      autoComplete='off'
+      type={inputType}
+      value={value}
+      onChange={(e) => onChange(e)}
+    />
   );
 };

--- a/FE/src/components/common/index.ts
+++ b/FE/src/components/common/index.ts
@@ -1,0 +1,6 @@
+export { AuthBackground } from './AuthBackground';
+export { TextDiv } from './TextDiv';
+export { TextInput } from './TextInput';
+export { Button } from './Button';
+export { LeftComponentBackGround } from './LeftComponentBackGround';
+export { RightComponentBackGround } from './RightComponentBackground';

--- a/FE/src/pages/index.tsx
+++ b/FE/src/pages/index.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
+import { Provider } from 'react-redux';
 import LoginComponent from '../components/LoginComponent/LoginComponent';
 import { GlobalStyle } from '../styles/GlobalStyle';
+import store from '../store/store';
 
 const Index: React.FunctionComponent = () => {
   return (
     <div>
-      <GlobalStyle />
-      <LoginComponent />
+      <Provider store={store}>
+        <GlobalStyle />
+        <LoginComponent />
+      </Provider>
     </div>
   );
 };

--- a/FE/src/store/modules/index.ts
+++ b/FE/src/store/modules/index.ts
@@ -1,0 +1,6 @@
+import { combineReducers } from 'redux';
+import user from './user';
+
+export default combineReducers({
+  user,
+});

--- a/FE/src/store/modules/user.ts
+++ b/FE/src/store/modules/user.ts
@@ -1,0 +1,37 @@
+import { loginAPI } from '../../api/index';
+
+const LOGIN_SUCCESS = 'user/LOGINS';
+
+export const requestLogin = (params: any) => {
+  /**
+   * @TODO
+   * API 맞춰서 작성하기
+   * const data = loginAPI(params);
+   */
+  const data = new Promise((resolve) => {
+    return resolve('check');
+  });
+
+  return {
+    type: LOGIN_SUCCESS,
+    payload: data,
+  };
+};
+
+const initialState = {
+  successLogin: '',
+};
+
+export default function user(state = initialState, action: any): any {
+  switch (action.type) {
+    case `${LOGIN_SUCCESS}_FULFILLED`:
+      console.log('LOGIN_SUCCESS Type', action);
+      return {
+        ...state,
+        successLogin: action.payload,
+      };
+    default:
+      console.log('Default Type:', action);
+      return state;
+  }
+}

--- a/FE/src/store/store.ts
+++ b/FE/src/store/store.ts
@@ -1,0 +1,8 @@
+import { applyMiddleware, createStore } from 'redux';
+import promiseMiddlerware from 'redux-promise-middleware';
+import reduxThunk from 'redux-thunk';
+import reducer from './modules';
+
+const createStoreWidthMiddleware = applyMiddleware(promiseMiddlerware, reduxThunk)(createStore);
+
+export default createStoreWidthMiddleware(reducer);


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- 공통 컴포넌트로 Auth, left, right 컴포넌트를 구현하였습니다.
- 깊이 있게 폴더구조를 만들었습니다.
  - 상태값의 전달이 필요하다면 context API, useContext를 사용하여 이동하면 됩니다.

## :hammer: 변경로직

- 공통 컴포넌트를 구현하였고, 사용시 children의 값들을 넣어주면 됩니다.
- 기존에 부모 컴포넌트에 있던 email, password 상태값을 right 자식 컴포넌트로 이동하였습니다.
  - 이벤트핸들러 자체를 자식컴포넌트에서 해결하게되면 불필요한 부모 컴포넌트의 렌더링 과정을 줄일 수 있어서 선택
- 컴포넌트 렌더링 과정을 확인하기 위해서 이벤트, 컴포넌트 마다 console.log로 렌더링 과정을 눈으로 확인중입니다. ( 추후에 완성되면 삭제할 예정)

## :camera_flash: 스크린샷 (Optional)
![image](https://user-images.githubusercontent.com/41230031/104673734-ab0b8f00-5725-11eb-8da9-bfd7f17fb73a.png)

## :lock: 관련 이슈(닫을 이슈)

- close #30
