### PR TITLE
[FE] Redux-thunk 및 Promise-then 적용

### DIFF
--- a/FE/src/components/LoginComponent/RightComponent/RightComponent.tsx
+++ b/FE/src/components/LoginComponent/RightComponent/RightComponent.tsx
@@ -27,12 +27,10 @@ export const RightComponent = (): JSX.Element => {
     e.preventDefault();
     console.log('click button');
     const params = { id: email, password };
-    dispatch(requestLogin(params)).then((res) => {
-      console.log(res);
-      setEmail('');
-      setPassword('');
-      // router.push('/');
-    });
+    dispatch(requestLogin(params));
+    setEmail('');
+    setPassword('');
+    // router.push('/');
   };
 
   return (

--- a/FE/src/lib/asyncUtils.ts
+++ b/FE/src/lib/asyncUtils.ts
@@ -1,0 +1,64 @@
+import { Dispatch } from 'react';
+
+export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>): any => {
+  const [PENDING, FULFILLED, REJECTED] = [`${type}_PENDING`, `${type}_FULFILLED`, `${type}_REJECTED`];
+
+  return (param: any) => (dispatch: Dispatch<any>) => {
+    dispatch({ type: PENDING, param });
+    promiseCreator(param)
+      .then((payload) => {
+        dispatch({ type: FULFILLED, payload });
+      })
+      .catch((payload) => {
+        dispatch({ type: REJECTED, payload });
+      });
+  };
+};
+
+export const reducerUtils = {
+  initial: (initialData = null): any => ({
+    loading: false,
+    loginSuccess: initialData,
+    error: null,
+  }),
+  loading: (prevState = null): any => ({
+    loading: true,
+    loginSuccess: prevState,
+    error: null,
+  }),
+  success: (payload: boolean): any => ({
+    loading: false,
+    loginSuccess: payload,
+    error: null,
+  }),
+  error: (error: Error): any => ({
+    loading: false,
+    loginSuccess: null,
+    error,
+  }),
+};
+
+export const handleAsyncActions = (type: string, key: string): any => {
+  const [PENDING, FULFILLED, REJECTED] = [`${type}_PENDING`, `${type}_FULFILLED`, `${type}_REJECTED`];
+  return (state: any, action: any) => {
+    switch (action.type) {
+      case PENDING:
+        return {
+          ...state,
+          [key]: reducerUtils.loading(),
+        };
+      case FULFILLED:
+        return {
+          ...state,
+          [key]: reducerUtils.success(action.payload),
+        };
+      case REJECTED:
+        return {
+          ...state,
+          [key]: reducerUtils.error(action.payload),
+        };
+      default:
+        return state;
+    }
+  };
+};

--- a/FE/src/store/modules/user.ts
+++ b/FE/src/store/modules/user.ts
@@ -1,39 +1,24 @@
+import { Dispatch } from 'react';
 import { loginAPI } from '../../api/index';
+import { createPromiseThunk, reducerUtils, handleAsyncActions } from '../../lib/asyncUtils';
 
-const LOGIN_SUCCESS = 'user/LOGINS';
+const LOGIN_PENDING = 'user/LOGIN_PENDING';
+const LOGIN_FULFILLED = 'user/LOGIN_FULFILLED';
+const LOGIN_REJECTED = 'user/LOGIN_REJECTED';
 
-export const requestLogin = (params: any) => {
-  /**
-   * @TODO
-   * API 맞춰서 작성하기
-   * const data = loginAPI(params);
-   */
-  const data = loginAPI(params);
-  console.log('result:', data);
-  // const data = new Promise((resolve) => {
-  //   return resolve('check');
-  // });
-
-  return {
-    type: LOGIN_SUCCESS,
-    payload: data,
-  };
-};
+export const requestLogin = createPromiseThunk('user/LOGIN', loginAPI);
 
 const initialState = {
-  successLogin: '',
+  user: reducerUtils.initial(),
 };
 
-export default function user(state = initialState, action: any): any {
+export default function posts(state = initialState, action: any): any {
   switch (action.type) {
-    case `${LOGIN_SUCCESS}_FULFILLED`:
-      console.log('LOGIN_SUCCESS Type', action);
-      return {
-        ...state,
-        successLogin: action.payload,
-      };
+    case LOGIN_PENDING:
+    case LOGIN_FULFILLED:
+    case LOGIN_REJECTED:
+      return handleAsyncActions('user/LOGIN', 'user')(state, action);
     default:
-      console.log('Default Type:', action);
       return state;
   }
 }

--- a/FE/src/store/store.ts
+++ b/FE/src/store/store.ts
@@ -5,10 +5,9 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import logger from 'redux-logger';
 import reducer from './modules';
 
-// const createStoreWidthMiddleware = applyMiddleware(promiseMiddlerware, reduxThunk)(createStore);
 const createStoreWidthMiddleware = createStore(
   reducer,
-  composeWithDevTools(applyMiddleware(logger, promiseMiddlerware, reduxThunk)),
-); // 여러개의 미들웨어를 적용 할 수 있습니다.
+  composeWithDevTools(applyMiddleware(promiseMiddlerware, reduxThunk, logger)),
+);
 
 export default createStoreWidthMiddleware;


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- Redux-thunk를 적용하기위해서
  -  관련 유틸함수를 구현하였습니다.
  - 디스패치의 액션으로 함수의 반환값이 아닌 함수를 넣어주기위해 클로저를 활용하여 액션생성함수를 구현하였습니다.
- API 호출하는 부분의 Promise-then을 적용하여 문제를 해결하였습니다.

## :hammer: 변경로직

```javascript
export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>): any => {
  const [PENDING, FULFILLED, REJECTED] = [`${type}_PENDING`, `${type}_FULFILLED`, `${type}_REJECTED`];

  return (param: any) => (dispatch: Dispatch<any>) => {
    dispatch({ type: PENDING, param });
    promiseCreator(param)
      .then((payload) => {
        dispatch({ type: FULFILLED, payload });
      })
      .catch((payload) => {
        dispatch({ type: REJECTED, payload });
      });
  };
};
```
- 함수의 반환 값이 아닌 함수를 디스패치에 넣어주기 위해서 위와 같이 구현하였다.
- 이를 통해서 내부적으로 pending을 통해 디스패치를 시작시켜주고, API를 호출하여 비동기 요청을 할 수 있도록 구현하였다.
## :camera_flash: 스크린샷 (Optional)
![image](https://user-images.githubusercontent.com/41230031/105064089-d264b200-5abf-11eb-8e98-8f90478acdd7.png)

## :lock: 관련 이슈(닫을 이슈)

- close #issueNumber
