### PR TITLE
[FE] Next에 Redux store, persistor 적용

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -8849,6 +8849,12 @@
         }
       }
     },
+    "next-redux-wrapper": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/next-redux-wrapper/-/next-redux-wrapper-6.0.2.tgz",
+      "integrity": "sha512-I9CnIYhQwI/qEoNdc9VAPjIyuq4rFFhCTa4rKhoDHWEVHGB1DXZy8TAyGpwvWizESd8IoTI/OKlP6bFpCbXsOw==",
+      "dev": true
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",

--- a/FE/package.json
+++ b/FE/package.json
@@ -47,6 +47,7 @@
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^4.5.0",
     "jest-dom": "^4.0.0",
+    "next-redux-wrapper": "^6.0.2",
     "prettier": "^2.2.1",
     "react-testing-library": "^8.0.1",
     "redux-logger": "^3.0.6",

--- a/FE/src/container/LoginContainer/RightContainer.tsx
+++ b/FE/src/container/LoginContainer/RightContainer.tsx
@@ -26,10 +26,9 @@ export const RightContainer = (): JSX.Element => {
     e.preventDefault();
     console.log('click button');
     const params = { id: email, password };
-    requestLogin(params).then((result) => dispatch(result));
-    // new Promise((resolve, reject) => {
-    //   resolve(dispatch(requestLogin(params)));
-    // }).then((result) => console.log('result:', result));
+    dispatch(requestLogin(params))
+      .then((res) => console.log(res))
+      .catch((err) => console.log('err check:', err));
     setEmail('');
     setPassword('');
     // router.push('/');

--- a/FE/src/lib/asyncUtils.ts
+++ b/FE/src/lib/asyncUtils.ts
@@ -1,19 +1,26 @@
 import { Dispatch } from 'react';
 
-export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>): any => {
-  const [PENDING, FULFILLED, REJECTED] = [`${type}_PENDING`, `${type}_FULFILLED`, `${type}_REJECTED`];
+export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>) => (
+  params: any,
+) => ({
+  type,
+  payload: promiseCreator(params),
+});
 
-  return (param: any) => (dispatch: Dispatch<any>) => {
-    dispatch({ type: PENDING, param });
-    promiseCreator(param)
-      .then((payload) => {
-        dispatch({ type: FULFILLED, payload });
-      })
-      .catch((payload) => {
-        dispatch({ type: REJECTED, payload });
-      });
-  };
-};
+// export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>): any => {
+//   const [PENDING, FULFILLED, REJECTED] = [`${type}_PENDING`, `${type}_FULFILLED`, `${type}_REJECTED`];
+
+//   return (param: any) => (dispatch: Dispatch<any>) => {
+//     dispatch({ type: PENDING, param });
+//     promiseCreator(param)
+//       .then((payload) => {
+//         dispatch({ type: FULFILLED, payload });
+//       })
+//       .catch((payload) => {
+//         dispatch({ type: REJECTED, payload });
+//       });
+//   };
+// };
 
 export const reducerUtils = {
   initial: (initialData = null): any => ({

--- a/FE/src/lib/asyncUtils.ts
+++ b/FE/src/lib/asyncUtils.ts
@@ -1,26 +1,9 @@
-import { Dispatch } from 'react';
-
 export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>) => (
   params: any,
 ) => ({
   type,
   payload: promiseCreator(params),
 });
-
-// export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>): any => {
-//   const [PENDING, FULFILLED, REJECTED] = [`${type}_PENDING`, `${type}_FULFILLED`, `${type}_REJECTED`];
-
-//   return (param: any) => (dispatch: Dispatch<any>) => {
-//     dispatch({ type: PENDING, param });
-//     promiseCreator(param)
-//       .then((payload) => {
-//         dispatch({ type: FULFILLED, payload });
-//       })
-//       .catch((payload) => {
-//         dispatch({ type: REJECTED, payload });
-//       });
-//   };
-// };
 
 export const reducerUtils = {
   initial: (initialData = null): any => ({

--- a/FE/src/pages/_app.tsx
+++ b/FE/src/pages/_app.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ReactReduxContext } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+import { GlobalStyle } from '../styles/GlobalStyle';
+import { wrapper } from '../store/store';
+
+export default wrapper.withRedux(function MyApp({ Component, pageProps }) {
+  return (
+    <ReactReduxContext.Consumer>
+      {({ store }) => {
+        return (
+          <PersistGate persistor={store.__persistor}>
+            <GlobalStyle />
+            <Component {...pageProps} />
+          </PersistGate>
+        );
+      }}
+    </ReactReduxContext.Consumer>
+  );
+});

--- a/FE/src/pages/index.tsx
+++ b/FE/src/pages/index.tsx
@@ -1,20 +1,11 @@
 import * as React from 'react';
-import { Provider } from 'react-redux';
-import { PersistGate } from 'redux-persist/integration/react';
 import LoginComponent from '../components/LoginComponent/LoginComponent';
-import { GlobalStyle } from '../styles/GlobalStyle';
-import { store, persistor } from '../store/store';
 
 const Index: React.FunctionComponent = () => {
   return (
-    <div>
-      <Provider store={store}>
-        <PersistGate persistor={persistor}>
-          <GlobalStyle />
-          <LoginComponent />
-        </PersistGate>
-      </Provider>
-    </div>
+    <>
+      <LoginComponent />
+    </>
   );
 };
 

--- a/FE/src/store/modules/index.ts
+++ b/FE/src/store/modules/index.ts
@@ -4,7 +4,7 @@ import storage from 'redux-persist/lib/storage';
 import user from './user';
 
 const persistConfig = {
-  key: 'root',
+  key: 'nextjs',
   storage,
   whitelist: ['user'],
 };

--- a/FE/src/store/store.ts
+++ b/FE/src/store/store.ts
@@ -4,13 +4,16 @@ import reduxThunk from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import logger from 'redux-logger';
 import { persistStore } from 'redux-persist';
+import { createWrapper } from 'next-redux-wrapper';
 import reducer from './modules';
 
-const store = createStore(
-  reducer,
-  composeWithDevTools(applyMiddleware(promiseMiddlerware, reduxThunk, logger)),
-);
+const middlewrares = [logger, promiseMiddlerware, reduxThunk];
 
-const persistor = persistStore(store);
+const makeStore = () => {
+  const store = createStore(reducer, undefined, composeWithDevTools(applyMiddleware(...middlewrares)));
+  store.__persistor = persistStore(store);
+  console.log('persist:', store.__persistor);
+  return store;
+};
 
-export { store, persistor };
+export const wrapper = createWrapper(makeStore);


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- next-redux-wrapper 를 사용하여 redux를 적용하였습니다.
- 전체 페이지에 store, persistor를 적용하기위해서 _app.tsx 파일을 생성하고 작성해줬습니다.
- _app.tsx를 적용하는 방법을 학습하였습니다.

## :hammer: 변경로직

```javascript
export default wrapper.withRedux(function MyApp({ Component, pageProps }) {
  return (
    <ReactReduxContext.Consumer>
      {({ store }) => {
        return (
          <PersistGate persistor={store.__persistor}>
            <GlobalStyle />
            <Component {...pageProps} />
          </PersistGate>
        );
      }}
    </ReactReduxContext.Consumer>
  );
});
```
Link, router를 통해 페이지에 접근하면 Component와 Props를 하나의 Store를 사용할 수 있도록하였습니다.
## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #92 #93
