### PR TITLE
[FE] Build & Export를 위한 Error Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *dist
 *.next/
 *.vscode/
+*out/

--- a/FE/src/container/LoginContainer/RightContainer.tsx
+++ b/FE/src/container/LoginContainer/RightContainer.tsx
@@ -22,16 +22,17 @@ export const RightContainer = (): JSX.Element => {
     setPassword(e.target.value);
   };
 
+  const pushStateHandler = () => {
+    router.push('/signup');
+  };
+
   const onClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
     console.log('click button');
     const params = { id: email, password };
-    dispatch(requestLogin(params))
-      .then((res) => console.log(res))
-      .catch((err) => console.log('err check:', err));
+    dispatch(requestLogin(params, pushStateHandler));
     setEmail('');
     setPassword('');
-    // router.push('/');
   };
 
   return (

--- a/FE/src/lib/asyncUtils.ts
+++ b/FE/src/lib/asyncUtils.ts
@@ -14,10 +14,6 @@ export const createPromiseThunk = (type: string, promiseCreator: (params: any) =
     });
   };
 };
-// ({
-//   type,
-//   payload: promiseCreator(params),
-// });
 
 export const reducerUtils = {
   initial: (initialData = null): any => ({

--- a/FE/src/lib/asyncUtils.ts
+++ b/FE/src/lib/asyncUtils.ts
@@ -1,9 +1,23 @@
 export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>) => (
   params: any,
-) => ({
-  type,
-  payload: promiseCreator(params),
-});
+  pushStateHandler: any,
+) => {
+  return (dispatch) => {
+    const response = dispatch({
+      type,
+      payload: promiseCreator(params),
+    });
+
+    response.then((res) => {
+      console.log('result:', res);
+      pushStateHandler();
+    });
+  };
+};
+// ({
+//   type,
+//   payload: promiseCreator(params),
+// });
 
 export const reducerUtils = {
   initial: (initialData = null): any => ({

--- a/FE/src/pages/_app.tsx
+++ b/FE/src/pages/_app.tsx
@@ -9,7 +9,7 @@ export default wrapper.withRedux(function MyApp({ Component, pageProps }) {
     <ReactReduxContext.Consumer>
       {({ store }) => {
         return (
-          <PersistGate persistor={store.__persistor}>
+          <PersistGate persistor={(store as any).__persistor}>
             <GlobalStyle />
             <Component {...pageProps} />
           </PersistGate>

--- a/FE/src/store/modules/index.ts
+++ b/FE/src/store/modules/index.ts
@@ -1,4 +1,5 @@
-import { combineReducers } from 'redux';
+import { RootStateOrAny } from 'react-redux';
+import { combineReducers, $CombinedState } from 'redux';
 import { persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import user from './user';
@@ -9,8 +10,9 @@ const persistConfig = {
   whitelist: ['user'],
 };
 
-const rootReducer = combineReducers({
-  user,
-});
-
-export default persistReducer(persistConfig, rootReducer);
+const rootReducer = function () {
+  return combineReducers({
+    user,
+  });
+};
+export default persistReducer<RootStateOrAny>(persistConfig, rootReducer());

--- a/FE/src/store/store.ts
+++ b/FE/src/store/store.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, createStore, $CombinedState } from 'redux';
 import promiseMiddlerware from 'redux-promise-middleware';
 import reduxThunk from 'redux-thunk';
 import { composeWithDevTools } from 'redux-devtools-extension';
@@ -11,8 +11,8 @@ const middlewrares = [logger, promiseMiddlerware, reduxThunk];
 
 const makeStore = () => {
   const store = createStore(reducer, undefined, composeWithDevTools(applyMiddleware(...middlewrares)));
-  store.__persistor = persistStore(store);
-  console.log('persist:', store.__persistor);
+  (store as any).__persistor = persistStore(store);
+  console.log('persist:', (store as any).__persistor);
   return store;
 };
 

--- a/FE/tsconfig.json
+++ b/FE/tsconfig.json
@@ -7,13 +7,13 @@
     "lib": [
       "ES2015",
       "DOM"
-    ], /* 컴파일에 포함될 라이브러리 파일 목록 */// "allowJs": true, /* 자바스크립트 파일 컴파일 허용 여부 */
+    ], /* 컴파일에 포함될 라이브러리 파일 목록 */ // "allowJs": true, /* 자바스크립트 파일 컴파일 허용 여부 */
     // "checkJs": true, /* .js 파일의 오류 검사 여부 */
     "jsx": "preserve", /* JSX 코드 생성 설정: 'preserve', 'react-native', 혹은 'react'. */
-    "declaration": true, /* '.d.ts' 파일 생성 여부. */// "declarationMap": true, /* 각 '.d.ts' 파일의 소스맵 생성 여부. */
+    "declaration": true, /* '.d.ts' 파일 생성 여부. */ // "declarationMap": true, /* 각 '.d.ts' 파일의 소스맵 생성 여부. */
     // "sourceMap": true, /* '.map' 파일 생성 여부. */
     // "outFile": "./", /* 단일 파일로 합쳐서 출력합니다. */
-    "outDir": "./dist/", /* 해당 디렉토리로 결과 구조를 보냅니다. */// "rootDir": "./", /* 입력 파일의 루트 디렉토리(rootDir) 설정으로 --outDir로 결과 디렉토리 구조를 조작할 때 사용됩니다. */
+    "outDir": "./dist/", /* 해당 디렉토리로 결과 구조를 보냅니다. */ // "rootDir": "./", /* 입력 파일의 루트 디렉토리(rootDir) 설정으로 --outDir로 결과 디렉토리 구조를 조작할 때 사용됩니다. */
     // "composite": true, /* 프로젝트 컴파일 여부 */
     // "tsBuildInfoFile": "./", /* 증분 컴파일 정보를 저장할 파일 */
     // "removeComments": true, /* 주석 삭제 여부 */
@@ -22,7 +22,7 @@
     // "downlevelIteration": true, /* 타겟이 'ES5', 'ES3'일 때에도 'for-of', spread 그리고 destructuring 문법 모두 지원 */
     // "isolatedModules": true, /* 각 파일을 분리된 모듈로 트랜스파일 ('ts.transpileModule'과 비슷합니다). */
     /* 엄격한 타입-확인 옵션 */
-    "strict": true, /* 모든 엄격한 타입-체킹 옵션 활성화 여부 */// "noImplicitAny": true, /* 'any' 타입으로 구현된 표현식 혹은 정의 에러처리 여부 */
+    // "strict": true, /* 모든 엄격한 타입-체킹 옵션 활성화 여부 */// "noImplicitAny": true, /* 'any' 타입으로 구현된 표현식 혹은 정의 에러처리 여부 */
     // "strictNullChecks": true, /* 엄격한 null 확인 여부 */
     // "strictFunctionTypes": true, /* 함수 타입에 대한 엄격한 확인 여부 */
     // "strictBindCallApply": true, /* 함수에 엄격한 'bind', 'call' 그리고 'apply' 메소드 사용 여부 */
@@ -36,19 +36,19 @@
     // "noFallthroughCasesInSwitch": true, /* switch문에서 fallthrough 케이스에 대한 에러보고 여부 */
     /* 모듈 해석 옵션 */
     "moduleResolution": "node", /* 모듈 해석 방법 설정: 'node' (Node.js) 혹은 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./", /* non-absolute한 모듈 이름을 처리할 기준 디렉토리 */// "paths": {}, /* 'baseUrl'를 기준으로 불러올 모듈의 위치를 재지정하는 엔트리 시리즈 */
+    "baseUrl": "./", /* non-absolute한 모듈 이름을 처리할 기준 디렉토리 */ // "paths": {}, /* 'baseUrl'를 기준으로 불러올 모듈의 위치를 재지정하는 엔트리 시리즈 */
     // "rootDirs": [], /* 결합된 컨텐츠가 런타임에서의 프로젝트 구조를 나타내는 루트 폴더들의 목록 */
     "typeRoots": [
       "./src/types",
       "./node_modules/@types"
-    ], /* 타입 정의를 포함할 폴더 목록, 설정 안 할 시 기본적으로 ./node_modules/@types로 설정 */// "types": [], /* 컴파일중 포함될 타입 정의 파일 목록 */
+    ], /* 타입 정의를 포함할 폴더 목록, 설정 안 할 시 기본적으로 ./node_modules/@types로 설정 */ // "types": [], /* 컴파일중 포함될 타입 정의 파일 목록 */
     // "allowSyntheticDefaultImports": true, /* default export이 아닌 모듈에서도 default import가 가능하게 할 지 여부, 해당 설정은 코드 추출에 영향은 주지 않고, 타입확인에만 영향을 줍니다. */
-    "esModuleInterop": true, /* 모든 imports에 대한 namespace 생성을 통해 CommonJS와 ES Modules 간의 상호 운용성이 생기게할 지 여부, 'allowSyntheticDefaultImports'를 암시적으로 승인합니다. */// "preserveSymlinks": true, /* symlik의 실제 경로를 처리하지 않을 지 여부 */
+    "esModuleInterop": true, /* 모든 imports에 대한 namespace 생성을 통해 CommonJS와 ES Modules 간의 상호 운용성이 생기게할 지 여부, 'allowSyntheticDefaultImports'를 암시적으로 승인합니다. */ // "preserveSymlinks": true, /* symlik의 실제 경로를 처리하지 않을 지 여부 */
     // "allowUmdGlobalAccess": true, /* UMD 전역을 모듈에서 접근할 수 있는 지 여부 */
     /* 소스 맵 옵션 */
     // "sourceRoot": "", /* 소스 위치 대신 디버거가 알아야 할 TypeScript 파일이 위치할 곳 */
     // "mapRoot": "", /* 생성된 위치 대신 디버거가 알아야 할 맵 파일이 위치할 곳 */
-    "inlineSourceMap": true, /* 분리된 파일을 가지고 있는 대신, 단일 파일을 소스 맵과 가지고 있을 지 여부 */// "inlineSources": true, /* 소스맵과 나란히 소스를 단일 파일로 내보낼 지 여부, '--inlineSourceMap' 혹은 '--sourceMap'가 설정되어 있어야 한다. */
+    "inlineSourceMap": true, /* 분리된 파일을 가지고 있는 대신, 단일 파일을 소스 맵과 가지고 있을 지 여부 */ // "inlineSources": true, /* 소스맵과 나란히 소스를 단일 파일로 내보낼 지 여부, '--inlineSourceMap' 혹은 '--sourceMap'가 설정되어 있어야 한다. */
     /* 실험적 옵션 */
     // "experimentalDecorators": true, /* ES7의 decorators에 대한 실험적 지원 여부 */
     // "emitDecoratorMetadata": true, /* decorator를 위한 타입 메타데이터를 내보내는 것에 대한 실험적 지원 여부 */
@@ -90,7 +90,8 @@
     "allowJs": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "strict": false
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
## :white_check_mark: 작업 내용

- thunk + Promise middleware 적용
- Type Error 수정

## :hammer: 변경로직

```javascript
export const createPromiseThunk = (type: string, promiseCreator: (params: any) => Promise<string>) => (
  params: any,
  pushStateHandler: any,
) => {
  return (dispatch) => {
    const response = dispatch({
      type,
      payload: promiseCreator(params),
    });

    response.then((res) => {
      console.log('result:', res);
      pushStateHandler();
    });
  };
};
```
기존에는 컨테이너안에서 then으로 기다렸지만 이보다 필요한 함수자체를 인자로 넘겨줘서 클로저를 통해 렉시컬 스코프를 기억하게 하여 사용할 수 있도록 하였습니다.


## :camera_flash: 스크린샷 (Optional)

## :lock: 관련 이슈(닫을 이슈)

- close #98
